### PR TITLE
CU-86b284aje: Freeze Nodes when Message is Selected

### DIFF
--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -30,9 +30,5 @@ body,
 }
 
 .react-flow__node > div {
-  @apply border-2 bg-slate-100 border-slate-400 transition-all;
-}
-
-.react-flow__node.selected > div {
-  @apply shadow-2xl bg-white border-[5px] border-green-500;
+  @apply border-2 bg-white border-slate-400 transition-all;
 }

--- a/src/components/graph/nodes/condition-node.tsx
+++ b/src/components/graph/nodes/condition-node.tsx
@@ -25,7 +25,7 @@ export default function ConditionNode({ id, data }: ConditionNodeProps) {
           onChange={handleInputChange}
           rows={1}
           placeholder="Enter your text here..."
-          className={`w-full px-3 py-2 rounded-lg bg-inherit border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 resize-none overflow-hidden`}
+          className={`w-full px-3 py-2 rounded-lg bg-inherit border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 resize-none overflow-hidden nodrag`}
         />
       </div>
 

--- a/src/components/graph/nodes/information-node.tsx
+++ b/src/components/graph/nodes/information-node.tsx
@@ -27,7 +27,7 @@ export default function InformationNode({ id, data }: InformationNodeProps) {
               name="dynamicGeneration"
               checked={data.dynamicGeneration}
               onChange={handleInputChange}
-              className="w-4 h-4 text-blue-600 bg-inherit rounded border-gray-300 focus:ring-blue-500 focus:ring-2"
+              className="w-4 h-4 bg-inherit text-blue-600 rounded border-gray-300 focus:ring-blue-500 focus:ring-2 nodrag"
             />
             <span className="ml-2 text-sm text-gray-700">Enable</span>
           </div>
@@ -41,7 +41,7 @@ export default function InformationNode({ id, data }: InformationNodeProps) {
             onChange={handleInputChange}
             rows={1}
             placeholder="Enter your text here..."
-            className="w-full px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 resize-none overflow-hidden"
+            className="w-full px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 resize-none overflow-hidden nodrag"
           />
         </div>
       </div>

--- a/src/components/graph/nodes/question-node.tsx
+++ b/src/components/graph/nodes/question-node.tsx
@@ -72,7 +72,7 @@ export default function QuestionNode({ id, data }: QuestionNodeProps) {
               name="dynamicGeneration"
               checked={data.dynamicGeneration}
               onChange={(e) => handleUpdate({ dynamicGeneration: e.target.checked })}
-              className="w-4 h-4 bg-inherit text-blue-600 rounded border-gray-300 focus:ring-blue-500 focus:ring-2"
+              className="w-4 h-4 bg-inherit text-blue-600 rounded border-gray-300 focus:ring-blue-500 focus:ring-2 nodrag"
             />
             <span className="ml-2 text-sm text-gray-700">Enable</span>
           </div>
@@ -83,7 +83,7 @@ export default function QuestionNode({ id, data }: QuestionNodeProps) {
             name="type"
             value={data.type}
             onChange={(e) => handleUpdate({ type: e.target.value as NodeType })}
-            className="w-full px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 appearance-none"
+            className="w-full px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 appearance-none nodrag"
           >
             {Object.values(NodeType).map((value) => (
               <option key={value} value={value} className="py-1">
@@ -101,7 +101,7 @@ export default function QuestionNode({ id, data }: QuestionNodeProps) {
             onChange={(e) => handleUpdate({ text: e.target.value })}
             rows={1}
             placeholder="Enter your text here..."
-            className="w-full px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 resize-none overflow-hidden"
+            className="w-full px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 resize-none overflow-hidden nodrag"
           />
         </div>
         {!data.dynamicGeneration && (data.type === NodeType.RatingSingle || data.type === NodeType.RatingMulti) && (
@@ -113,11 +113,11 @@ export default function QuestionNode({ id, data }: QuestionNodeProps) {
                   type="text"
                   defaultValue={rating}
                   onChange={(e) => handleRatingChange(index, e.target.value)}
-                  className="flex-grow px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200"
+                  className="flex-grow px-3 py-2 bg-inherit rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 nodrag"
                 />
                 <button
                   onClick={() => removeRating(index)}
-                  className="px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600 transition duration-200"
+                  className="px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600 transition duration-200 nodrag"
                 >
                   Remove
                 </button>
@@ -125,7 +125,7 @@ export default function QuestionNode({ id, data }: QuestionNodeProps) {
             ))}
             <button
               onClick={addRating}
-              className="px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition duration-200"
+              className="px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition duration-200 nodrag"
             >
               Add Rating
             </button>


### PR DESCRIPTION
## Description 📝

This PR enables `nodrag` on all input elements inside of the nodes.

## How Has This Been Tested? 🔍

- [ ] Tested that you can drag a node when you select any element but the input.
- [ ] Tested that you cannot drag a node when you select any inputs.

## Motivation and Context 🎯

So that users can easily copy and paste content to and from nodes without accidentally dragging them.

## ClickUp Task 📌

[CU-86b284aje](https://app.clickup.com/t/86b284aje)
