### PR TITLE
CU-86b30wckq: Added Unrecoverable Subscription Error Handling

### DIFF
--- a/src/pages/user-inquiry.tsx
+++ b/src/pages/user-inquiry.tsx
@@ -187,8 +187,8 @@ export default function UserInquiryPage() {
     [addMessage, audioEnabled, audio, handleNextNode],
   );
 
-  const onError = () => {
-    addAlert('This response is taking longer than expected...', 'error');
+  const onError = (error: Error) => {
+    addAlert(error.message || 'An error occurred while processing the inquiry. Please try again later.', 'warning');
   };
 
   /*================================ EVENT HANDLERS ==============================*/
@@ -273,7 +273,7 @@ export default function UserInquiryPage() {
     const description = (startNode?.data?.text as string) ?? '';
 
     return (
-      <div className="bg-white dark:bg-slate-700 p-6 rounded-lg shadow-lg">
+      <div className="bg-white dark:bg-slate-700 p-6 rounded-3xl shadow-lg">
         <h2 className="text-2xl font-bold mb-4 text-slate-800 dark:text-white">{form.title}</h2>
         <p className="text-slate-600 dark:text-slate-300 mb-6">{description}</p>
         <div className="space-y-4">
@@ -342,7 +342,7 @@ export default function UserInquiryPage() {
   );
 
   const renderSummary = () => (
-    <div className="bg-white dark:bg-slate-800 p-6 rounded-lg shadow-lg">
+    <div className="bg-white dark:bg-slate-800 p-6 rounded-3xl shadow-lg">
       <h2 className="text-2xl font-bold mb-4 text-slate-800 dark:text-white text-center">Thank you!</h2>
       <p className="text-lg text-slate-600 dark:text-slate-300 text-center">Your responses have been recorded.</p>
 
@@ -451,7 +451,7 @@ export default function UserInquiryPage() {
   );
 
   const renderNotFound = () => (
-    <div className="bg-white dark:bg-slate-700 p-6 rounded-lg shadow-lg">
+    <div className="bg-white dark:bg-slate-700 p-6 rounded-3xl shadow-lg">
       <h2 className="text-2xl font-bold mb-4 text-slate-800 dark:text-white">Inquiry Not Found</h2>
       <p className="text-slate-600 dark:text-slate-300 mb-6">
         The inquiry you are looking for does not exist. Please check the URL and try again.
@@ -460,7 +460,7 @@ export default function UserInquiryPage() {
   );
 
   const renderError = () => (
-    <div className="bg-white dark:bg-slate-700 p-6 rounded-lg shadow-lg">
+    <div className="bg-white dark:bg-slate-700 p-6 rounded-3xl shadow-lg">
       <h2 className="text-2xl font-bold mb-4 text-slate-800 dark:text-white">Something Went Wrong</h2>
       <p className="text-slate-600 dark:text-slate-300 mb-6">
         An error occurred while loading the inquiry. Please try again later.
@@ -485,7 +485,7 @@ export default function UserInquiryPage() {
         {state.error && renderError()}
         <div ref={messagesEndRef} />
       </div>
-      {(screen === 'inquiry' || screen === 'end') && renderInputArea()}
+      {(screen === 'inquiry' || screen === 'end') && !state.error && renderInputArea()}
     </>
   );
 }

--- a/src/providers/inquiry-traversal-provider.tsx
+++ b/src/providers/inquiry-traversal-provider.tsx
@@ -170,6 +170,9 @@ function InquiryTraversalProvider({ children, id, preview }: InquiryProviderProp
           if (onSubscriptionDataRef.current) {
             onSubscriptionDataRef.current(content);
           }
+        } else if (prediction?.type === PredictionType.Error) {
+          setState((prev) => ({ ...prev, loading: false, error: true }));
+          handleError(new Error(`An error occurred on our end, please try again later.`), false);
         }
       } catch (e) {
         setState((prev) => ({ ...prev, loading: true }));
@@ -249,21 +252,28 @@ function InquiryTraversalProvider({ children, id, preview }: InquiryProviderProp
     }
   }
 
-  async function handleError(error: Error) {
-    // setState((prev) => ({ ...prev, error: true }));
+  /**
+   * Handles an error that occurs during the node traversal process.
+   * Optionally, it can retry the process if the retry flag is set to true.
+   * @param error
+   * @param retry
+   */
+  async function handleError(error: Error, retry = true) {
     if (onNodeErrorRef.current) {
       onNodeErrorRef.current(error);
     }
 
-    await addPrediction({
-      variables: {
-        ...lastPredictionVariablesRef.current,
-        input: {
-          ...(lastPredictionVariablesRef.current?.input ?? {}),
-          errorHandling: error?.message || 'An error occurred,  please identify and resolve the issue.',
+    if (retry) {
+      await addPrediction({
+        variables: {
+          ...lastPredictionVariablesRef.current,
+          input: {
+            ...(lastPredictionVariablesRef.current?.input ?? {}),
+            errorHandling: error?.message || 'An error occurred,  please identify and resolve the issue.',
+          },
         },
-      },
-    });
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Description 📝

As it stands, when a subscription fails for User Inquiry, we are not handling "hard" errors where the API itself fails for X, Y, Z reason. This PR adds in a check to API errors and displays the error accordingly to users like so:

![image](https://github.com/user-attachments/assets/00548abf-8d78-4cf4-a5c4-5a75236dbe27)

## How Has This Been Tested? 🔍

- [x] Ran through several inquiries forcing an API side error by blocking local request to the Bedrock API.

## Motivation and Context 🎯

To indicate to users when an unrecoverable error occurs so that they can quit the Inquiry without being confused.

## ClickUp Task 📌

[CU-86b30wckq](https://app.clickup.com/t/86b30wckq)
