### PR TITLE
CU-86b318wpm-Dynamic-Generation-Click-Issue

### DIFF
--- a/src/components/graph/nodes/information-node.tsx
+++ b/src/components/graph/nodes/information-node.tsx
@@ -36,7 +36,7 @@ export default function InformationNode({ id, data }: InformationNodeProps) {
     <NodeContainer title="Information" faIcon={faExclamationCircle} id={id}>
       <Input
         label="Dynamic Generation"
-        name="dynamicGeneration"
+        name={`dynamicGeneration-${id}`}
         type="checkbox"
         checked={data.dynamicGeneration}
         onChange={(e) => handleUpdate({ dynamicGeneration: (e.target as HTMLInputElement).checked })}

--- a/src/components/graph/nodes/question-node.tsx
+++ b/src/components/graph/nodes/question-node.tsx
@@ -66,7 +66,7 @@ export default function QuestionNode({ id, data }: QuestionNodeProps) {
     <NodeContainer title="Question" faIcon={faQuestionCircle} id={id}>
       <Input
         label="Dynamic Generation"
-        name="dynamicGeneration"
+        name={`dynamicGeneration-${id}`}
         type="checkbox"
         checked={data.dynamicGeneration}
         onChange={(e) => handleUpdate({ dynamicGeneration: (e.target as HTMLInputElement).checked })}


### PR DESCRIPTION
## Description 📝

Clicking the text of "dynamic generation" it still toggles the first node's checkbox, now it doesn't 

## How Has This Been Tested? 🔍

- [x] Clicked on a node with "Dynamic Generation"

## Motivation and Context 🎯

Please describe the reason for the changes.

## ClickUp Task 📌

[CU-86b318wpm](https://app.clickup.com/t/86b318wpm)
