### PR TITLE
Random condition node

### DIFF
--- a/src/components/graph/elements/condition.tsx
+++ b/src/components/graph/elements/condition.tsx
@@ -42,7 +42,7 @@ const Condition = ({ to, condition, probability, nodeId, nodeColor, isRandom, on
       value: dest.id,
     })),
   );
-  
+
   // Calculate relative luminance of bg color and determine text color
   const hex = nodeColor.substring(1);
   const [r, g, b] = [hex.substring(0, 2), hex.substring(2, 4), hex.substring(4)].map((n) => parseInt(n, 16) / 255);

--- a/src/components/graph/nodes/condition-node.tsx
+++ b/src/components/graph/nodes/condition-node.tsx
@@ -96,13 +96,13 @@ export default function ConditionNode({ id, data }: ConditionNodeProps) {
           </div>
         ))}
       </div>
-      
+
       {isRandom && (
         <div className="mt-4 text-sm text-gray-600 dark:text-gray-300">
           <strong>Note:</strong> The sum of all probabilities must equal 1.00
         </div>
       )}
-      
+
       <div className="mt-4">
         <Button
           className="nodrag mt-2 w-full"
@@ -114,9 +114,7 @@ export default function ConditionNode({ id, data }: ConditionNodeProps) {
             let newCondition;
             if (isRandom) {
               // Calculate remaining probability: 1 - sum of all existing probabilities
-              const existingSum = data.conditions.reduce((sum, condition) => 
-                sum + (condition.probability || 0), 0
-              );
+              const existingSum = data.conditions.reduce((sum, condition) => sum + (condition.probability || 0), 0);
               const remainingProbability = Math.max(0, 1 - existingSum);
               // Round to 2 decimal places to avoid floating point precision issues
               const roundedProbability = Math.round(remainingProbability * 100) / 100;

--- a/src/pages/dashboard/inquiry-builder/tabs/analysis/per-question.tsx
+++ b/src/pages/dashboard/inquiry-builder/tabs/analysis/per-question.tsx
@@ -248,16 +248,19 @@ const PerQuestionTab: React.FC<PerQuestionTabProps> = ({ id }) => {
       <div className="my-4">
         <h2 className="font-bold mb-2">Select Question</h2>
         <div className="grid grid-cols-4 sm:grid-col-3 lg:grid-cols-6 gap-2">
-          {questionNodes.map((node: GraphNode, index: number) => (
-            <Button
-              key={node.id}
-              onClick={() => setCurrentQuestionIndex(index)}
-              variant={currentQuestionIndex === index ? 'primary' : 'secondary'}
-              title={node.data?.text || `Question ${index + 1}`}
-            >
-              {truncateText(node.data?.text || `Question ${index + 1}`)}
-            </Button>
-          ))}
+          {questionNodes.map((node: GraphNode, index: number) => {
+            const questionData = node.data as QuestionNodeData;
+            return (
+              <Button
+                key={node.id}
+                onClick={() => setCurrentQuestionIndex(index)}
+                variant={currentQuestionIndex === index ? 'primary' : 'secondary'}
+                title={questionData?.text || `Question ${index + 1}`}
+              >
+                {truncateText(questionData?.text || `Question ${index + 1}`)}
+              </Button>
+            );
+          })}
         </div>
       </div>{' '}
       {currentSummary && showSummary && (

--- a/src/providers/inquiry-traversal-provider.tsx
+++ b/src/providers/inquiry-traversal-provider.tsx
@@ -392,14 +392,14 @@ function InquiryTraversalProvider({ children, id, preview }: InquiryProviderProp
 
     // Check if this is a random condition node
     const isRandom = currentNode.data.random ?? false;
-    
+
     if (isRandom) {
       // Handle random branching locally
       const conditions = currentNode.data.conditions as { to: string; probability?: number }[];
-      const validConditions = conditions.filter(cond => 
-        graphRef.current?.getOutgoingNodes().some(node => node.id === cond.to)
+      const validConditions = conditions.filter((cond) =>
+        graphRef.current?.getOutgoingNodes().some((node) => node.id === cond.to),
       );
-      
+
       if (validConditions.length === 0) {
         handleError(new Error('No valid outgoing nodes found for random condition'));
         return;
@@ -408,7 +408,7 @@ function InquiryTraversalProvider({ children, id, preview }: InquiryProviderProp
       // Weighted random selection
       const totalWeight = validConditions.reduce((sum, cond) => sum + (cond.probability || 0), 0);
       let random = Math.random() * totalWeight;
-      
+
       let selectedNode = validConditions[0]; // fallback
       for (const condition of validConditions) {
         random -= condition.probability || 0;

--- a/src/utils/analysis-data-minimizer.ts
+++ b/src/utils/analysis-data-minimizer.ts
@@ -53,7 +53,7 @@ export function minimizeAnalysisData(
         // Only include supported question types
         if (['single-select', 'multi-select', 'open-ended'].includes(nodeType)) {
           questions[node.id] = {
-            text: node.data.text || '',
+            text: nodeData.text || '',
             type: nodeType as 'single-select' | 'multi-select' | 'open-ended',
             ...(nodeData.ratings &&
               ['single-select', 'multi-select'].includes(nodeType) && {

--- a/src/utils/graphs/graph-utils.ts
+++ b/src/utils/graphs/graph-utils.ts
@@ -275,20 +275,20 @@ export function validateGraph(graph: StrippedGraph): { valid: boolean; errors: s
         }
 
         // Check if condition node has appropriate data based on mode
-        // Note: We have to as any here because the type of node.data.conditions is not inferred correctly on account
+        // Note: We have to cast here because the type of node.data.conditions is not inferred correctly on account
         //       of the library we are using for the graph editor.
-        const conditions = (node.data.conditions as { to: string; condition?: string; probability?: number }[]);
-        const isRandom = (node.data as any).random ?? false;
-        
+        const conditions = node.data.conditions as { to: string; condition?: string; probability?: number }[];
+        const isRandom = (node.data as Record<string, unknown>).random === true;
+
         if (isRandom) {
           // For random mode, check probabilities
-          const missingProbabilities = conditions.filter(cond => typeof cond.probability !== 'number');
+          const missingProbabilities = conditions.filter((cond) => typeof cond.probability !== 'number');
           if (missingProbabilities.length > 0) {
             errors.push(
               `Random condition node "${id}" has paths without probability values. Please add probability values for all paths.`,
             );
           }
-          
+
           const totalProbability = conditions.reduce((sum, cond) => sum + (cond.probability || 0), 0);
           if (Math.abs(totalProbability - 1.0) > 0.01) {
             errors.push(
@@ -297,7 +297,11 @@ export function validateGraph(graph: StrippedGraph): { valid: boolean; errors: s
           }
         } else {
           // For deterministic mode, check conditions
-          if (conditions.some((cond: { to: string; condition?: string }) => !cond.condition || cond.condition.trim() === '')) {
+          if (
+            conditions.some(
+              (cond: { to: string; condition?: string }) => !cond.condition || cond.condition.trim() === '',
+            )
+          ) {
             errors.push(
               `Condition node "${id}" is missing its decision criteria. Please add a condition to specify how the flow should branch.`,
             );


### PR DESCRIPTION
This pull request introduces support for random branching in condition nodes within the graph editor, allowing users to specify probabilistic routing in addition to deterministic conditions. The changes add a "Random" mode to condition nodes, update the UI to handle probability inputs, and ensure proper validation and traversal logic for random branches.

**Condition Node Enhancements:**

* Added a "Random" checkbox to condition nodes (`ConditionNode`), which toggles between deterministic (condition-based) and random (probability-based) modes. In random mode, users can set probabilities for each outgoing path, and the UI displays a note reminding users that probabilities must sum to 1.0. [[1]](diffhunk://#diff-cefb49dbabeae766d8ee839131679d0a3ca2648a105bfa945145a970f3b112faR53-R105) [[2]](diffhunk://#diff-cefb49dbabeae766d8ee839131679d0a3ca2648a105bfa945145a970f3b112faL78-R125)
* Updated the `Condition` component to support both modes: it now renders probability inputs for random mode and condition text areas for deterministic mode. The component's props and change handlers were adjusted accordingly. [[1]](diffhunk://#diff-80ea4e79141393f34a9c360318902a3419e5d68eb39996e416aa35a97115be4fR8-R21) [[2]](diffhunk://#diff-80ea4e79141393f34a9c360318902a3419e5d68eb39996e416aa35a97115be4fL27-R36) [[3]](diffhunk://#diff-80ea4e79141393f34a9c360318902a3419e5d68eb39996e416aa35a97115be4fL44-R130)

**Graph Traversal and Validation Logic:**

* Modified the graph traversal provider to handle random condition nodes by selecting the next node based on weighted probabilities, instead of using AI agent evaluation.
* Updated graph validation to check that, in random mode, all paths have probability values and that their sum is approximately 1.0. In deterministic mode, it continues to require decision criteria for each path.

**Minor Fixes and Refactoring:**

* Improved type safety and clarity in question node handling and analysis data minimization. [[1]](diffhunk://#diff-6e18e94dfe7e286d6be36f0680aef79bbddf3ca4713058241a458cc0ffcfcfdaL56-R56) [[2]](diffhunk://#diff-958acaa220a394ae3dbc602ae63841f120941b9731f8c61558e191bfef1d5af4L251-R263)